### PR TITLE
Feature/allow specification of schema directory

### DIFF
--- a/argo_metadata_validator/schema_utils.py
+++ b/argo_metadata_validator/schema_utils.py
@@ -59,7 +59,7 @@ def _retrieve_from_filesystem(uri: str, schema_dir: Path = None):
 
 def _get_registry(schema_file_path: Path = None):
     schema_dir = None if schema_file_path is None else schema_file_path.parent
-    return Registry(retrieve=functools.partial(_retrieve_from_filesystem, schema_dir = schema_dir))
+    return Registry(retrieve=functools.partial(_retrieve_from_filesystem, schema_dir=schema_dir))
 
 
 def infer_schema_from_data(data: dict) -> str:

--- a/argo_metadata_validator/schema_utils.py
+++ b/argo_metadata_validator/schema_utils.py
@@ -1,5 +1,6 @@
 """Utilities related to the schema validation."""
 
+import functools
 from pathlib import Path
 
 import jsonschema.validators
@@ -49,15 +50,16 @@ def _get_schema_file(schema_type: str, version: str = DEFAULT_SCHEMA_VERSION) ->
     return schema_dir / f"argo.{schema_type}.schema.json"
 
 
-def _retrieve_from_filesystem(uri: str):
-    schema_dir = _get_schema_dir()
+def _retrieve_from_filesystem(uri: str, schema_dir: Path = None):
+    schema_dir = _get_schema_dir() if schema_dir is None else schema_dir
     file = Path(uri).name
     path = schema_dir / file
     return Resource.from_contents(load_json(path))
 
 
-def _get_registry():
-    return Registry(retrieve=_retrieve_from_filesystem)
+def _get_registry(schema_file_path: Path = None):
+    schema_dir = None if schema_file_path is None else schema_file_path.parent
+    return Registry(retrieve=functools.partial(_retrieve_from_filesystem, schema_dir = schema_dir))
 
 
 def infer_schema_from_data(data: dict) -> str:
@@ -98,6 +100,23 @@ def get_json_validator(schema_type: str, version: str = DEFAULT_SCHEMA_VERSION) 
     schema_file = _get_schema_file(schema_type, version)
     schema = load_json(schema_file)
     registry = _get_registry()
+
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator: Validator = validator_cls(schema, registry=registry)
+    return validator
+
+
+def get_json_validator_for_user_schema(schema_file_path: Path) -> Validator:
+    """Returns a jsonschema Validator for a user-supplied schema file.
+
+    Args:
+        schema_file_path (Path): The path to the schema file.
+
+    Returns:
+        Validator: validator with the appropriate schema loaded in.
+    """
+    schema = load_json(schema_file_path)
+    registry = _get_registry(schema_file_path)
 
     validator_cls = jsonschema.validators.validator_for(schema)
     validator: Validator = validator_cls(schema, registry=registry)

--- a/argo_metadata_validator/validation.py
+++ b/argo_metadata_validator/validation.py
@@ -11,7 +11,12 @@ from argo_metadata_validator.models.float import Float
 from argo_metadata_validator.models.platform import Platform
 from argo_metadata_validator.models.results import ValidationError
 from argo_metadata_validator.models.sensor import Sensor
-from argo_metadata_validator.schema_utils import get_json_validator, infer_schema_from_data, infer_version_from_data
+from argo_metadata_validator.schema_utils import (
+    get_json_validator,
+    get_json_validator_for_user_schema,
+    infer_schema_from_data,
+    infer_version_from_data,
+)
 from argo_metadata_validator.utils import load_json
 from argo_metadata_validator.vocab_utils import VocabTerms, expand_vocab, update_terms_from_context
 
@@ -111,7 +116,7 @@ class ArgoValidator:
             print(f"Validating against schema version {schema_version}")
             json_validator = get_json_validator(schema_type, version=schema_version)
         else:
-            pass
+            json_validator = get_json_validator_for_user_schema(schema_path)
 
         errors = []
 

--- a/argo_metadata_validator/validation.py
+++ b/argo_metadata_validator/validation.py
@@ -50,11 +50,13 @@ class ArgoValidator:
                 # Load the JSON file into memory
                 self.all_json_data[file.name] = load_json(Path(item))
 
-    def validate(self, json_obj: list[str | dict]) -> dict[str, list[ValidationError]]:
+    def validate(self, json_obj: list[str | dict], schema_path: Path = None) -> dict[str, list[ValidationError]]:
         """Takes a list of JSON files or dictionaries and validates each.
 
         Args:
             json_obj (list[str|dict]): List of file paths or JSON dictionaries.
+            schema_path (Path, optional): A path to a schema file. Defaults to None. If not provided,
+                the schema will be inferred from field in the json_obj.
 
         Returns:
             dict[str, list[str]]: Errors, keyed by the input filename.
@@ -63,7 +65,7 @@ class ArgoValidator:
 
         self.validation_errors = {}
         for file, json_data in self.all_json_data.items():
-            self.validation_errors[file] = self._validate_json(json_data)
+            self.validation_errors[file] = self._validate_json(json_data, schema_path)
 
             if not self.validation_errors[file]:
                 self.validation_errors[file] += self._validate_vocabs(json_data)
@@ -93,19 +95,23 @@ class ArgoValidator:
             return Platform(**data)
         raise Exception("Data does not match a defined Python model.")
 
-    def _validate_json(self, json_data: Any) -> list[ValidationError]:
+    def _validate_json(self, json_data: Any, schema_path: Path = None) -> list[ValidationError]:
         """Apply JSON schema validation to given JSON data.
 
         Args:
             json_data (Any): JSON content to check.
+            schema_path (Path, optional): A path to a schema file. Defaults to None.
 
         Returns:
             list[str]: List of errors.
         """
-        schema_type = infer_schema_from_data(json_data)
-        schema_version = infer_version_from_data(json_data)
-        print(f"Validating against schema version {schema_version}")
-        json_validator = get_json_validator(schema_type, version=schema_version)
+        if schema_path is None:
+            schema_type = infer_schema_from_data(json_data)
+            schema_version = infer_version_from_data(json_data)
+            print(f"Validating against schema version {schema_version}")
+            json_validator = get_json_validator(schema_type, version=schema_version)
+        else:
+            pass
 
         errors = []
 

--- a/argo_metadata_validator/validation.py
+++ b/argo_metadata_validator/validation.py
@@ -202,8 +202,8 @@ class ArgoValidator:
                     val = expand_vocab(context, val)
                     if not self._is_active_term(val):
                         if self._is_deprecated_term(val):
-                            error = ValidationError(message=f"Deprecated NSV term: {val}", path=f"{field}.{idx}.{x}")
+                            error = ValidationError(message=f"Deprecated NVS term: {val}", path=f"{field}.{idx}.{x}")
                         else:
-                            error = ValidationError(message=f"Unknown NSV term: {val}", path=f"{field}.{idx}.{x}")
+                            error = ValidationError(message=f"Unknown NVS term: {val}", path=f"{field}.{idx}.{x}")
                         errors.append(error)
         return errors

--- a/tests/files/user_defined/invalid_sensor.json
+++ b/tests/files/user_defined/invalid_sensor.json
@@ -1,0 +1,154 @@
+{
+    "sensor_info": {
+      "created_by": "johert",
+      "date_creation": "2025-12-23T14:00:00Z",
+      "link" : "./sensor.schema.json",
+      "format_version": "0.4.0",
+      "contents": "json file to describe a sensor v0.4.0 draft",
+      "sensor_described": "AANDERAA-TOOL1239-421"
+    },
+    "@context": {
+      "SDN:P01::": "http://vocab.nerc.ac.uk/collection/P01/current/",
+      "SDN:L05::": "http://vocab.nerc.ac.uk/collection/L05/current/",
+      "SDN:L35::": "http://vocab.nerc.ac.uk/collection/L35/current/",
+      "SDN:L22::": "http://vocab.nerc.ac.uk/collection/L22/current/"
+    },
+  "SENSORZ": [
+      {
+        "SENSOR": "SDN:L05::351",
+        "SENSOR_MAKER": "SDN:L35::MAN0007",
+        "SENSOR_MODEL": "SDN:L22::TOOL1239",
+        "SENSOR_MODEL_FIRMWARE": " ",
+        "SENSOR_SERIAL_NO": "421"
+      }
+    ],
+    "PARAMETERS": [
+      {
+        "PARAMETER": "SDN:P01::DOXYAAOP",
+        "PARAMETER_SENSOR": "SDN:L05::351",
+        "PARAMETER_UNITS": "degree",
+        "PARAMETER_ACCURACY": " ",
+        "PARAMETER_RESOLUTION": " ",
+        "PREDEPLOYMENT_CALIB_EQUATION": "none",
+        "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": {  },
+        "PREDEPLOYMENT_CALIB_COMMENT": "Phase measurement with blue excitation light; see TD269 Operating manual oxygen optode 4330, 4835, 483",
+        "PREDEPLOYMENT_CALIB_DATE": " "
+      },
+      {
+        "PARAMETER": "SDN:P01::OXYCOPVB",
+        "PARAMETER_SENSOR": "SDN:L05::351",
+        "PARAMETER_UNITS": "degree",
+        "PARAMETER_ACCURACY": " ",
+        "PARAMETER_RESOLUTION": " ",
+        "PREDEPLOYMENT_CALIB_EQUATION": "none",
+        "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": { },
+        "PREDEPLOYMENT_CALIB_COMMENT": "Phase measurement with red excitation light; see TD269 Operating manual oxygen optode 4330, 4835, 4831",
+        "PREDEPLOYMENT_CALIB_DATE": " "    
+      },
+      {
+        "PARAMETER": "SDN:P01::OXYCOPVR",
+        "PARAMETER_SENSOR": "SDN:L05::351",
+        "PARAMETER_UNITS": "degC",
+        "PARAMETER_ACCURACY": "0.03",
+        "PARAMETER_RESOLUTION": "0.01",
+        "PREDEPLOYMENT_CALIB_EQUATION": "TEMP_DOXY=T0+T1*TEMP_VOLTAGE_DOXY+T2*TEMP_VOLTAGE_DOXY^2+T3*TEMP_VOLTAGE_DOXY^3+T4*TEMP_VOLTAGE_DOXY^4+T5*TEMP_VOLTAGE_DOXY^5; with TEMP_VOLTAGE_DOXY=voltage from thermistor bridge (mV)",
+        "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": {
+          "T0": "1",
+          "T1": "2",
+          "T2": "3",
+          "T3": "4",
+          "T4": "5",
+          "T5": "6"
+        },
+        "PREDEPLOYMENT_CALIB_COMMENT": "optode temperature, see TD269 Operating manual oxygen optode 4330, 4835, 4831",
+        "PREDEPLOYMENT_CALIB_DATE": "2020-01-01T00:00:00Z"
+      },
+      {
+        "PARAMETER": "SDN:P01::OXYCPHAB",
+        "PARAMETER_SENSOR": "SDN:L05::351",
+        "PARAMETER_UNITS": "umol/kg",
+        "PARAMETER_ACCURACY": "8 umol/kg or 10%",
+        "PARAMETER_RESOLUTION": "1 umol/kg",
+        "PREDEPLOYMENT_CALIB_EQUATION": "TPHASE_DOXY=C1PHASE_DOXY-C2PHASE_DOXY; Phase_Pcorr=TPHASE_DOXY+Pcoef1*PRES/1000; CalPhase=PhaseCoef0+PhaseCoef1*Phase_Pcorr+PhaseCoef2*Phase_Pcorr^2+PhaseCoef3*Phase_Pcorr^3; MOLAR_DOXY=[((c3+c4*TEMP_DOXY)/(c5+c6*CalPhase))-1]/Ksv; Ksv=c0+c1*TEMP_DOXY+c2*TEMP_DOXY^2; O2=MOLAR_DOXY*Scorr*Pcorr; Scorr=A*exp[PSAL*(B0+B1*Ts+B2*Ts^2+B3*Ts^3)+C0*PSAL^2]; A=[(1013.25-pH2O(TEMP,Spreset))/(1013.25-pH2O(TEMP,PSAL))]; pH2O(TEMP,S)=1013.25*exp[D0+D1*(100/(TEMP+273.15))+D2*ln((TEMP+273.15)/100)+D3*S]; Pcorr=1+((Pcoef2*TEMP+Pcoef3)*PRES)/1000; Ts=ln[(298.15-TEMP)/(273.15+TEMP)]; DOXY=O2/rho, where rho is the potential density [kg/L] calculated from CTD data",
+        "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": {
+          "Spreset": "0",
+          "Pcoef1": "0.1",
+          "Pcoef2": "0.00022",
+          "Pcoef3": "0.0419",
+          "B0": "0.00624523",
+          "B1": "-0.00737614",
+          "B2": "-0.010341",
+          "B3": "-0.00817083",
+          "C0": "3.1201642E-3",
+          "PhaseCoef0": "-1.652",
+          "PhaseCoef1": "1",
+          "PhaseCoef2": "0",
+          "PhaseCoef3": "0",
+          "c0": "0.00261275",
+          "c1": "0.00011268",
+          "c2": "2.2309e-06",
+          "c3": "200.183",
+          "c4": "-0.223497",
+          "c5": "-43.6776",
+          "c6": "4.10578",
+          "D0": "24.4543",
+          "D1": "-67.4509",
+          "D2": "-4.8489",
+          "D3": "-0.000544",
+          "C1": "-285.56594E-6",
+          "C2": "316.32993E-9",
+          "C3": "-1.0767272E-6"
+        },
+        "PREDEPLOYMENT_CALIB_COMMENT": "see TD269 Operating manual oxygen optode 4330, 4835, 4831; see Processing Argo OXYGEN data at the DAC level, Version 2.2 (DOI: http://dx.doi.org/10.13155/39795)",
+        "PREDEPLOYMENT_CALIB_DATE": "2020-01-01T00:00:00Z",
+        "parameter_vendorinfo": {
+          "example": "Vendors can add their own parameter info here; they can add any field they like as a fieldname below parameter_vendorinfo"
+        },
+        "predeployment_vendorinfo": {
+          "example": "Vendors can add their own predeployment info here; they can add any field they like as a fieldname below predeployment_vendorinfo"
+        }
+      },
+      {
+        "PARAMETER": "SDN:P01::OXYCPHAC",
+        "PARAMETER_SENSOR": "SDN:L05::351",
+        "PARAMETER_UNITS": "mbar",
+        "PARAMETER_ACCURACY": " ",
+        "PARAMETER_RESOLUTION": " ",
+        "PREDEPLOYMENT_CALIB_EQUATION": "TPHASE_DOXY=C1PHASE_DOXY-C2PHASE_DOXY; Phase_Pcorr=TPHASE_DOXY+Pcoef1*PRES/1000; CalPhase=PhaseCoef0+PhaseCoef1*Phase_Pcorr+PhaseCoef2*Phase_Pcorr^2+PhaseCoef3*Phase_Pcorr^3; Ksv=c0+c1*TEMP_DOXY+c2*TEMP_DOXY^2; MOLAR_DOXY=[((c3+c4*TEMP_DOXY)/(c5+c6*CalPhase))-1]/Ksv; Pcorr=1+((Pcoef2*TEMP+Pcoef3)*PRES)/1000; MOLAR_DOXY=MOLAR_DOXY*Pcorr; pH2Osat=1013.25*exp[D0+D1*(100/(TEMP+273.15))+D2*ln((TEMP+273.15)/100)]; Tcorr=44.6596*exp[2.00907+3.22014*Ts+4.05010*Ts^2+4.94457*Ts^3-2.56847e-1*Ts^4+3.88767*Ts^5]; Ts=ln[(298.15-TEMP)/(273.15+TEMP)]; PPOX_DOXY=MOLAR_DOXY*(0.20946*(1013.25-pH2Osat))/Tcorr*exp[0.317*PRES/(8.314*(TEMP+273.15))]",
+        "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": {
+          "Pcoef1": "0.1",
+          "Pcoef2": "0.00022",
+          "Pcoef3": "0.0419",
+          "PhaseCoef0": "-1.652",
+          "PhaseCoef1": "1",
+          "PhaseCoef2": "0",
+          "PhaseCoef3": "0",
+          "c0": "0.00261275",
+          "c1": "0.00011268",
+          "c2": "2.2309e-06",
+          "c3": "200.183",
+          "c4": "-0.223497",
+          "c5": "-43.6776",
+          "c6": "4.10578",
+          "D0": "24.4543",
+          "D1": "-67.4509",
+          "D2": "-4.8489",
+          "C0": "3.1201642E-3",
+          "C1": "-285.56594E-6",
+          "C2": "316.32993E-9",
+          "C3": "-1.0767272E-6"
+        },
+        "PREDEPLOYMENT_CALIB_COMMENT": "see TD269 Operating manual oxygen optode 4330, 4835, 4831; see Processing Argo OXYGEN data at the DAC level, Version 2.2 (DOI: http://dx.doi.org/10.13155/39795)",
+        "PREDEPLOYMENT_CALIB_DATE": "2020-01-01T00:00:00Z",
+        "parameter_vendorinfo": {
+          "example": "Vendors can add their own parameter info here; they can add any field they like as a fieldname below parameter_vendorinfo"
+        },
+        "predeployment_vendorinfo": {
+          "example": "Vendors can add their own predeployment info here; they can add any field they like as a fieldname below predeployment_vendorinfo"
+        }
+      }
+    ],
+    "instrument_vendorinfo": {
+      "example": "Vendors can add something about the whole instrument here; they can add field they like as a fieldname below instrument_vendorinfo"
+    }
+  }

--- a/tests/files/user_defined/schema/RBR.schema.json
+++ b/tests/files/user_defined/schema/RBR.schema.json
@@ -1,0 +1,68 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "./RBR.schema.json",
+    "title": "JSON Schema for sensors",
+    "description": "A JSON Schema used to populate sensor configuration and parameter metadata elements specific to RBR.",
+    "version" : {"const" : "0.1"},
+    "type": "object",
+    "$defs": {
+        "sensor_vendorinfo": {
+            "type": "object",
+            "properties": {
+                "vendor_schema" : true,
+                "version" : {"$ref": "#/version"},
+                "RBR_foo1": {
+                    "type": "number"
+                },
+                "RBR_foo2": {
+                    "type": "string"
+                }
+            },
+            "required" : ["RBR_foo1", "RBR_foo2"],
+            "additionalProperties" : false
+        },
+        "parameter_vendorinfo": {
+            "type": "object",
+            "properties": {
+                "vendor_schema" : true,
+                "version" : {"$ref": "#/version"},
+                "RBR_foo3": {
+                    "type": "number"
+                },
+                "RBR_foo4": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "predeployment_vendorinfo": {
+            "type": "object",
+            "properties": {
+                "vendor_schema" : true,
+                "version" : {"$ref": "#/version"},
+                "certificate": {
+                    "type" : "string",
+                    "format": "uri",
+                    "desription" : "Link to calibration certificate"
+                }
+            },
+            "required" : ["certificate"],
+            "additionalProperties" : false
+        },
+        "instrument_vendorinfo": {
+            "type": "object",
+            "properties": {
+                "vendor_schema" : true,
+                "version" : {"$ref": "#/version"},
+                "RBR_foo7": {
+                    "type": "number"
+                },
+                "RBR_foo8": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties" : false
+        }
+
+    }
+}

--- a/tests/files/user_defined/schema/SBE.schema.json
+++ b/tests/files/user_defined/schema/SBE.schema.json
@@ -1,0 +1,268 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "./SBE.schema.json",
+    "title": "JSON Schema for sensors",
+    "description": "A JSON Schema used to populate sensor configuration and parameter metadata elements specific to SBE.  ",
+    "version" : {"const" : "0.2"},
+    "type": "object",
+    "$defs": {
+        "sensor_vendorinfo": {
+            "type": "object",
+            "properties": {
+                "vendor_schema" : true,
+                "version" : {"$ref": "#/version"},
+                "SBE_manufacturing_date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "SBE_ISFET_SERIAL_NO": {
+                    "type": "string"
+                },
+                "SBE_REFERENCE_SERIAL_NO": {
+                    "type": "string"
+                },
+                "SBE_pHType": {
+                    "type": "string",
+                    "enum" : ["Float", "Deep", "LOV", "Stem,", "Glider pH"]
+                },
+                "CONFIG_EcoCdomFluorescenceExcitationWavelength_nm": {
+                    "type": "number",
+                    "const": 370
+                },
+                "CONFIG_EcoCdomFluorescenceExcitationBandwidth_nm": {
+                    "type": "number",
+                    "const": 15
+                },
+                "CONFIG_EcoCdomFluorescenceEmissionWavelength_nm": {
+                    "type": "number",
+                    "const": 460
+                },
+                "CONFIG_EcoCdomFluorescenceEmissionBandwidth_nm": {
+                    "type": "number",
+                    "const": 120
+                },
+                "CONFIG_EcoChlaFluorescenceExcitationWavelength_nm": {
+                    "type": "number",
+                    "enum": [435, 470]
+                },
+                "CONFIG_EcoChlaFluorescenceExcitationBandwidth_nm": {
+                    "type": "number",
+                    "enum": [23,24]
+                },
+                "CONFIG_EcoChlaFluorescenceEmissionWavelength_nm": {
+                    "type": "number",
+                    "const": 695
+                },
+                "CONFIG_EcoChlaFluorescenceEmissionBandwidth_nm": {
+                    "type": "number",
+                    "const": 70
+                },
+                "CONFIG_EcoChlaFluorescenceExcitationWavelength1_nm": {
+                    "type": "number",
+                    "const": 470
+                },
+                "CONFIG_EcoChlaFluorescenceExcitationBandwidth1_nm": {
+                    "type": "number",
+                    "const": 23
+                },
+                "CONFIG_EcoChlaFluorescenceEmissionWavelength1_nm": {
+                    "type": "number",
+                    "const": 695
+                },
+                "CONFIG_EcoChlaFluorescenceEmissionBandwidth1_nm": {
+                    "type": "number",
+                    "const": 70
+                },
+                "CONFIG_EcoChlaFluorescenceExcitationWavelength2_nm": {
+                    "type": "number",
+                    "const": 435
+                },
+                "CONFIG_EcoChlaFluorescenceExcitationBandwidth2_nm": {
+                    "type": "number",
+                    "const": 15
+                },
+                "CONFIG_EcoChlaFluorescenceEmissionWavelength2_nm": {
+                    "type": "number",
+                    "const": 695
+                },
+                "CONFIG_EcoChlaFluorescenceEmissionBandwidth2_nm": {
+                    "type": "number",
+                    "const": 70
+                },
+                "CONFIG_EcoBetaWavelength_nm": {
+                    "type": "number",
+                    "enum": [412, 440, 470, 488, 510, 532, 595, 650, 676, 700, 715]
+                },
+                "CONFIG_EcoBetaBandwidth_nm": {
+                    "type": "number",
+                    "enum": [20, 25]
+                },
+                "CONFIG_EcoBetaAngle_angularDeg": {
+                    "type": "number",
+                    "enum": [124, 142, 150]
+                },
+                "CONFIG_EcoBetaWavelength1_nm": {
+                    "type": "number",
+                    "enum": [412, 440, 470, 488, 510, 532, 595, 650, 676, 700, 715]
+                },
+                "CONFIG_EcoBetaBandwidth1_nm": {
+                    "type": "number",
+                    "const": 25
+                },
+                "CONFIG_EcoBetaAngle_angularDeg1": {
+                    "type": "number",
+                    "enum": [124, 142, 150]
+                },
+                "CONFIG_EcoBetaWavelength2_nm": {
+                    "type": "number",
+                    "enum": [412, 440, 470, 488, 510, 532, 595, 650, 676, 700, 715]
+                },
+                "CONFIG_EcoBetaBandwidth2_nm": {
+                    "type": "number",
+                    "const": 25
+                },
+                "CONFIG_EcoBetaAngle_angularDeg2": {
+                    "type": "number",
+                    "enum": [124, 142, 150]
+                },
+                "CONFIG_OcrDownIrrWavelength1_nm": {
+                    "type": "integer",
+                    "enum": [380],
+                    "maximum" : 900
+                },
+                "CONFIG_OcrDownIrrBandwidth1_nm": {
+                    "type": "number",
+                    "enum": [10]
+                },
+                "CONFIG_OcrDownIrrWavelength2_nm": {
+                    "type": "number",
+                    "enum": [412, 443],
+                    "maximum" : 900
+                },
+                "CONFIG_OcrDownIrrBandwidth2_nm": {
+                    "type": "number",
+                    "enum": [10]
+                },
+                "CONFIG_OcrDownIrrWavelength3_nm": {
+                    "type": "number",
+                    "enum": [490],
+                    "maximum" : 900
+                },
+                "CONFIG_OcrDownIrrBandwidth3_nm": {
+                    "type": "number",
+                    "enum": [10]
+                },
+                "CONFIG_OcrDownIrrWavelength4_nm": {
+                    "type": "number",
+                    "enum": [555]
+                },
+                "CONFIG_OcrDownIrrBandwidth4_nm": {
+                    "type": "number",
+                    "enum": [10]
+    
+                },
+                "CONFIG_SunaApfFrameOutputPixelBegin_NUMBER": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum" : 256
+                },
+                "CONFIG_SunaApfFrameOutputPixelEnd_NUMBER": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum" : 256
+                },
+                "CONFIG_EcoVerticalPressureOffset_dbar": {
+                    "type": "number",
+                    "minimum": -2.0,
+                    "maximum" : 2.0
+                },
+                "CONFIG_OcrVerticalPressureOffset_dbar": {
+                    "type": "number",
+                    "minimum": -2.0,
+                    "maximum" : 2.0
+                },
+                "CONFIG_OptodeVerticalPressureOffset_dbar": {
+                    "type": "number",
+                    "minimum": -2.0,
+                    "maximum" : 2.0
+                },
+                "CONFIG_SunaVerticalPressureOffset_dbar": {
+                    "type": "number",
+                    "minimum": -2.0,
+                    "maximum" : 2.0
+                }
+            },
+        "required" : ["vendor_schema", "version"],
+            "additionalProperties" : false
+        },
+        "parameter_vendorinfo": {
+            "type": "object",
+            "version" : {"$ref": "#/version"},
+            "properties": {
+                "vendor_schema" : true,
+                "version" : {"$ref": "#/version"},
+                "SBE_calfile": {
+                    "type": "string"
+                },
+                "SBE_optional3": {
+                    "type": "number"
+                },
+                "SBE_optional4": {
+                    "type": "string"
+                }
+            },
+            "required" : ["vendor_schema", "version"],
+            "additionalProperties" : false
+        },
+        "predeployment_vendorinfo": {
+            "type": "object",
+            "version" : {"$ref": "#/version"},
+            "properties": {
+                "vendor_schema" : true,
+                "version" : {"$ref": "#/version"},
+                "PREDEPLOYMENT_SEAFET_K0_CALIB_DATE": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "PREDEPLOYMENT_SEAFET_K2_CALIB_DATE": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            },
+            "required" : ["vendor_schema", "version"],
+            "additionalProperties" : false
+        },
+        "instrument_vendorinfo": {
+            "type": "object",
+            "version" : {"$ref": "#/version"},
+            "properties": {
+                "vendor_schema" : true,
+                "version" : {"$ref": "#/version"},
+                "SBE_part_number": {
+                    "type": "string"
+                }
+            },
+            "required" : ["vendor_schema", "version"],
+            "additionalProperties" : false
+        },
+        "platform_vendorinfo": {
+            "type": "object",
+            "version" : {"$ref": "#/version"},
+            "properties": {
+                "vendor_schema" : true,
+                "version" : {"$ref": "#/version"},
+                "SBE_manufacturing_date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "SBE_part_number": {
+                    "type": "string"
+                }
+            },
+            "required" : ["vendor_schema", "version", "SBE_manufacturing_date"],
+            "additionalProperties" : false
+        }
+
+
+    }
+}

--- a/tests/files/user_defined/schema/sensor.schema.json
+++ b/tests/files/user_defined/schema/sensor.schema.json
@@ -1,0 +1,194 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "./sensor.schema.json",
+    "title": "JSON Schema for sensors",
+    "description": "A JSON Schema used to attribute calibration information to parameter and sensor metadata elements. This is a copy of the Argo metadata format Version 3.41.1",
+    "format_version": { "const": "0.4.0" },
+    "type": "object",
+    "properties": {
+        "sensor_info": {
+            "type": "object",
+            "properties": {
+                "created_by": {
+                    "type": "string"
+                },
+                "date_creation": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "link": {
+                    "const" : "./sensor.schema.json"
+                },
+                "format_version": {
+                    "$ref": "#/format_version"
+                },
+                "contents": {
+                    "type": "string"
+                },
+                "sensor_described": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "created_by",
+                "date_creation",
+                "link",
+                "format_version",
+                "contents",
+                "sensor_described"
+            ]
+        },
+        "@context": {
+            "type": "object",
+            "properties": {
+                "SDN:P01::": { "const": "http://vocab.nerc.ac.uk/collection/P01/current/" },
+                "SDN:L05::": { "const": "http://vocab.nerc.ac.uk/collection/L05/current/" },
+                "SDN:L35::": { "const": "http://vocab.nerc.ac.uk/collection/L35/current/" },
+                "SDN:L22::": { "const": "http://vocab.nerc.ac.uk/collection/L22/current/" }
+            },
+            "required": [
+                "SDN:P01::",
+                "SDN:L05::",
+                "SDN:L35::",
+                "SDN:L22::"
+            ],
+            "additionalProperties": false
+        },
+        "SENSORS": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "SENSOR": {
+                        "type" : "string",
+                        "format" : "uri",
+                        "pattern" : "^SDN:L05::",
+                        "description": "SENSOR string must be valid in current NVS reference table L05",
+                        "validation-uri" : "https://vocab.nerc.ac.uk/collection/L05/current/"
+                    },
+                    "SENSOR_MAKER": {
+                        "type" : "string",
+                        "format" : "uri",
+                        "pattern" : "^SDN:L35::",
+                        "description": "SENSOR_MAKER string must be valid in current NVS reference table L35",
+                        "validation-uri": "https://vocab.nerc.ac.uk/collection/L35/current/"
+                    },
+                    "SENSOR_MODEL": {
+                        "type" : "string",
+                        "format" : "uri",
+                        "pattern" : "^SDN:L22::",
+                        "description": "SENSOR_MODEL string must be valid in current NVS reference table L22",
+                        "validation-uri": "https://vocab.nerc.ac.uk/collection/L22/current/"
+                    },
+                    "SENSOR_MODEL_FIRMWARE": {
+                        "type": "string",
+                        "description": "Firmware version of this sensor_model, defined by the sensor_maker"
+                    },
+                    "SENSOR_SERIAL_NO": {
+                        "type": "string",
+                        "description": "Serial number of the sensor"
+                    },
+                    "sensor_vendorinfo": {
+                        "$ref" : "./vendors.schema.json#/$defs/sensor_vendorinfo"                        
+                    }
+                },
+                "required": [
+                    "SENSOR",
+                    "SENSOR_MAKER",
+                    "SENSOR_MODEL",
+                    "SENSOR_SERIAL_NO",
+                    "SENSOR_MODEL_FIRMWARE"
+                ],
+                "additionalProperties": false
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "PARAMETERS": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "PARAMETER": {
+                        "type" : "string",
+                        "format" : "uri",
+                        "pattern" : "^SDN:P01::",
+                        "description": "PARAMETER string must be valid in current NVS reference table P01",
+                        "validation_uri": "http://vocab.nerc.ac.uk/collection/P01/current/"
+                    },
+                    "PARAMETER_SENSOR": {
+                        "type" : "string",
+                        "format" : "uri",
+                        "pattern" : "^SDN:L05::",
+                        "description": "PARAMETER_SENSOR string must be valid in current NVS reference table L05 and must be listed as a SENSOR in the SENSORS section above",
+                        "validation_uri": "http://vocab.nerc.ac.uk/collection/L05/current/"
+                    },
+                    "PARAMETER_UNITS": {
+                        "type": "string"
+                    },
+                    "PARAMETER_ACCURACY": {
+                        "type": "string"
+                    },
+                    "PARAMETER_RESOLUTION": {
+                        "type": "string"
+                    },
+                    "PREDEPLOYMENT_CALIB_EQUATION": {
+                        "type": "string",
+                        "description" : "Calibration equation for this parameter."
+                    },
+                    "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": {
+                        "type": "object",
+                        "description" : "Calibation coefficients are listed individually here, string-encoded to guarantee precision.  They are compiled to create the PREDEPLOYMENT_CALIB_COEFFCIENT string"
+                    },
+                    "PREDEPLOYMENT_CALIB_COMMENT": {
+                        "type": "string"
+                    },
+                    "PREDEPLOYMENT_CALIB_DATE": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "string",
+                                "const": " "
+                            }
+                        ]
+                    },
+                    "parameter_vendorinfo": {
+                        "$ref" : "./vendors.schema.json#/$defs/parameter_vendorinfo"
+                    },
+                    "predeployment_vendorinfo": {
+                        "$ref" : "./vendors.schema.json#/$defs/predeployment_vendorinfo"
+                    }
+                },
+                "required": [
+                    "PARAMETER",
+                    "PARAMETER_SENSOR",
+                    "PARAMETER_UNITS",
+                    "PARAMETER_ACCURACY",
+                    "PARAMETER_RESOLUTION",
+                    "PREDEPLOYMENT_CALIB_EQUATION",
+                    "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST",
+                    "PREDEPLOYMENT_CALIB_COMMENT",
+                    "PREDEPLOYMENT_CALIB_DATE"
+                ],
+                "additionalProperties": false
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "instrument_vendorinfo": {
+            "$ref" : "./vendors.schema.json#/$defs/instrument_vendorinfo"
+        }
+    },
+    "required": [
+        "@context",
+        "sensor_info",
+        "SENSORS",
+        "PARAMETERS"
+    ],
+    "uniqueItems": true,
+    "additionalProperties": false
+
+}

--- a/tests/files/user_defined/schema/vendors.schema.json
+++ b/tests/files/user_defined/schema/vendors.schema.json
@@ -1,0 +1,248 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "./vendor.schema.json",
+    "title": "JSON Schema for sensors : Vendor-specific information",
+    "description": "A JSON Schema used to populate vendor-specific sensor and parameter metadata elements.",
+    "version" : "0.1",
+    "type": "object",
+    "$defs": {
+        "sensor_vendorinfo": {
+            "type": "object",
+            "properties": {
+                "vendor_schema": {
+                    "type": "string",
+                    "enum": [
+                        "None",
+                        "SBE",
+                        "RBR"
+                    ],
+                    "default": "None"
+                },
+                "version" : {"type" : "string"}
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"vendor_schema": {"const": "None"}}
+                    },
+                    "then": {
+                        "additionalProperties": {
+                            "__comment__": {
+                                "description": "sensor_vendorinfo is optional. When vendor schema is unspecified or None, content is uncontrolled",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "vendor_schema": { "const": "SBE" } },
+                        "required": [ "vendor_schema"]
+                    },
+                    "then": { 
+                        "$ref": "./SBE.schema.json#/$defs/sensor_vendorinfo"
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "vendor_schema": { "const": "RBR" }},
+                        "required": [ "vendor_schema"]
+                    },
+                    "then": {
+                        "$ref": "./RBR.schema.json#/$defs/sensor_vendorinfo"
+                    }
+                }
+            ]
+        },
+        "parameter_vendorinfo": {
+            "type": "object",
+            "properties": {
+                "vendor_schema": {
+                    "type": "string",
+                    "enum": [
+                        "None",
+                        "SBE",
+                        "RBR"
+                    ],
+                    "default": "None"
+                },
+                "version" : {"type" : "string"}
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"vendor_schema": {"const": "None"}}
+                    },
+                    "then": {
+                        "additionalProperties": {
+                            "__comment__": {
+                                "description": "parameter_vendorinfo is optional. When vendor schema is unspecified or None, content is uncontrolled",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "vendor_schema": { "const": "SBE" } },
+                        "required": [ "vendor_schema"]
+                    },
+                    "then": { 
+                        "$ref": "./SBE.schema.json#/$defs/parameter_vendorinfo"
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "vendor_schema": { "const": "RBR" }},
+                        "required": [ "vendor_schema"]
+                    },
+                    "then": {
+                        "$ref": "./RBR.schema.json#/$defs/parameter_vendorinfo"
+                    }
+                }
+            ]
+        },
+        "predeployment_vendorinfo": {
+            "type": "object",
+            "properties": {
+                "vendor_schema": {
+                    "type": "string",
+                    "enum": [
+                        "None",
+                        "RBR",
+                        "SBE"
+                    ],
+                    "default": "None"
+                },
+                "version" : {"type" : "string"}
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"vendor_schema": {"const": "None"}}
+                    },
+                    "then": {
+                        "additionalProperties": {
+                            "__comment__": {
+                                "description": "predeployment_vendorinfo is optional. When vendor schema is unspecified or None, content is uncontrolled",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "vendor_schema": { "const": "RBR" } },
+                        "required": [ "vendor_schema"]
+                    },
+                    "then": { 
+                        "$ref": "./RBR.schema.json#/$defs/predeployment_vendorinfo"
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "vendor_schema": { "const": "SBE" } },
+                        "required": [ "vendor_schema"]
+                    },
+                    "then": { 
+                        "$ref": "./SBE.schema.json#/$defs/predeployment_vendorinfo"
+                    }
+                }
+
+            ]
+        },
+        "instrument_vendorinfo": {
+            "type": "object",
+            "properties": {
+                "vendor_schema": {
+                    "type": "string",
+                    "enum": [
+                        "None",
+                        "SBE"
+                    ],
+                    "default": "None"
+                },
+                "version" : {"type" : "string"}
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"vendor_schema": {"const": "None"}}
+                    },
+                    "then": {
+                        "additionalProperties": {
+                            "__comment__": {
+                                "description": "instrument_vendorinfo is optional. When vendor_schema is unspecified or None, content is uncontrolled",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "vendor_schema": { "const": "SBE" } },
+                        "required": [ "vendor_schema"]
+                    },
+                    "then": { 
+                        "$ref": "./SBE.schema.json#/$defs/instrument_vendorinfo"
+                    }
+                }
+            ]
+        },
+        
+        "platform_vendorinfo": {
+            "type": "object",
+            "properties": {
+                "vendor_schema": {
+                    "type": "string",
+                    "enum": [
+                        "None",
+                        "SBE",
+                        "MRV"
+                    ],
+                    "default": "None"
+                },
+                "version" : {"type" : "string"}
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"vendor_schema": {"const": "None"}}
+                    },
+                    "then": {
+                        "additionalProperties": {
+                            "__comment__": {
+                                "description": "instrument_vendorinfo is optional. When vendor_schema is unspecified or None, content is uncontrolled",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "vendor_schema": { "const": "SBE" } },
+                        "required": [ "vendor_schema"]
+                    },
+                    "then": { 
+                        "$ref": "./SBE.schema.json#/$defs/platform_vendorinfo"
+                    }
+                },
+
+                {
+                    "if": {
+                        "properties": { "vendor_schema": { "const": "MRV" }},
+                        "required": [ "vendor_schema"]
+                    },
+                    "then": {
+                        "$ref": "./MRV.schema.json#/$defs/platform_vendorinfo"
+                    }
+                }
+
+
+
+            ]
+        }                            
+
+
+    }
+}

--- a/tests/files/user_defined/valid_sensor.json
+++ b/tests/files/user_defined/valid_sensor.json
@@ -1,0 +1,154 @@
+{
+    "sensor_info": {
+      "created_by": "johert",
+      "date_creation": "2025-12-23T14:00:00Z",
+      "link" : "./sensor.schema.json",
+      "format_version": "0.4.0",
+      "contents": "json file to describe a sensor v0.4.0 draft",
+      "sensor_described": "AANDERAA-TOOL1239-421"
+    },
+    "@context": {
+      "SDN:P01::": "http://vocab.nerc.ac.uk/collection/P01/current/",
+      "SDN:L05::": "http://vocab.nerc.ac.uk/collection/L05/current/",
+      "SDN:L35::": "http://vocab.nerc.ac.uk/collection/L35/current/",
+      "SDN:L22::": "http://vocab.nerc.ac.uk/collection/L22/current/"
+    },
+  "SENSORS": [
+      {
+        "SENSOR": "SDN:L05::351",
+        "SENSOR_MAKER": "SDN:L35::MAN0007",
+        "SENSOR_MODEL": "SDN:L22::TOOL1239",
+        "SENSOR_MODEL_FIRMWARE": " ",
+        "SENSOR_SERIAL_NO": "421"
+      }
+    ],
+    "PARAMETERS": [
+      {
+        "PARAMETER": "SDN:P01::DOXYAAOP",
+        "PARAMETER_SENSOR": "SDN:L05::351",
+        "PARAMETER_UNITS": "degree",
+        "PARAMETER_ACCURACY": " ",
+        "PARAMETER_RESOLUTION": " ",
+        "PREDEPLOYMENT_CALIB_EQUATION": "none",
+        "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": {  },
+        "PREDEPLOYMENT_CALIB_COMMENT": "Phase measurement with blue excitation light; see TD269 Operating manual oxygen optode 4330, 4835, 483",
+        "PREDEPLOYMENT_CALIB_DATE": " "
+      },
+      {
+        "PARAMETER": "SDN:P01::OXYCOPVB",
+        "PARAMETER_SENSOR": "SDN:L05::351",
+        "PARAMETER_UNITS": "degree",
+        "PARAMETER_ACCURACY": " ",
+        "PARAMETER_RESOLUTION": " ",
+        "PREDEPLOYMENT_CALIB_EQUATION": "none",
+        "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": { },
+        "PREDEPLOYMENT_CALIB_COMMENT": "Phase measurement with red excitation light; see TD269 Operating manual oxygen optode 4330, 4835, 4831",
+        "PREDEPLOYMENT_CALIB_DATE": " "    
+      },
+      {
+        "PARAMETER": "SDN:P01::OXYCOPVR",
+        "PARAMETER_SENSOR": "SDN:L05::351",
+        "PARAMETER_UNITS": "degC",
+        "PARAMETER_ACCURACY": "0.03",
+        "PARAMETER_RESOLUTION": "0.01",
+        "PREDEPLOYMENT_CALIB_EQUATION": "TEMP_DOXY=T0+T1*TEMP_VOLTAGE_DOXY+T2*TEMP_VOLTAGE_DOXY^2+T3*TEMP_VOLTAGE_DOXY^3+T4*TEMP_VOLTAGE_DOXY^4+T5*TEMP_VOLTAGE_DOXY^5; with TEMP_VOLTAGE_DOXY=voltage from thermistor bridge (mV)",
+        "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": {
+          "T0": "1",
+          "T1": "2",
+          "T2": "3",
+          "T3": "4",
+          "T4": "5",
+          "T5": "6"
+        },
+        "PREDEPLOYMENT_CALIB_COMMENT": "optode temperature, see TD269 Operating manual oxygen optode 4330, 4835, 4831",
+        "PREDEPLOYMENT_CALIB_DATE": "2020-01-01T00:00:00Z"
+      },
+      {
+        "PARAMETER": "SDN:P01::OXYCPHAB",
+        "PARAMETER_SENSOR": "SDN:L05::351",
+        "PARAMETER_UNITS": "umol/kg",
+        "PARAMETER_ACCURACY": "8 umol/kg or 10%",
+        "PARAMETER_RESOLUTION": "1 umol/kg",
+        "PREDEPLOYMENT_CALIB_EQUATION": "TPHASE_DOXY=C1PHASE_DOXY-C2PHASE_DOXY; Phase_Pcorr=TPHASE_DOXY+Pcoef1*PRES/1000; CalPhase=PhaseCoef0+PhaseCoef1*Phase_Pcorr+PhaseCoef2*Phase_Pcorr^2+PhaseCoef3*Phase_Pcorr^3; MOLAR_DOXY=[((c3+c4*TEMP_DOXY)/(c5+c6*CalPhase))-1]/Ksv; Ksv=c0+c1*TEMP_DOXY+c2*TEMP_DOXY^2; O2=MOLAR_DOXY*Scorr*Pcorr; Scorr=A*exp[PSAL*(B0+B1*Ts+B2*Ts^2+B3*Ts^3)+C0*PSAL^2]; A=[(1013.25-pH2O(TEMP,Spreset))/(1013.25-pH2O(TEMP,PSAL))]; pH2O(TEMP,S)=1013.25*exp[D0+D1*(100/(TEMP+273.15))+D2*ln((TEMP+273.15)/100)+D3*S]; Pcorr=1+((Pcoef2*TEMP+Pcoef3)*PRES)/1000; Ts=ln[(298.15-TEMP)/(273.15+TEMP)]; DOXY=O2/rho, where rho is the potential density [kg/L] calculated from CTD data",
+        "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": {
+          "Spreset": "0",
+          "Pcoef1": "0.1",
+          "Pcoef2": "0.00022",
+          "Pcoef3": "0.0419",
+          "B0": "0.00624523",
+          "B1": "-0.00737614",
+          "B2": "-0.010341",
+          "B3": "-0.00817083",
+          "C0": "3.1201642E-3",
+          "PhaseCoef0": "-1.652",
+          "PhaseCoef1": "1",
+          "PhaseCoef2": "0",
+          "PhaseCoef3": "0",
+          "c0": "0.00261275",
+          "c1": "0.00011268",
+          "c2": "2.2309e-06",
+          "c3": "200.183",
+          "c4": "-0.223497",
+          "c5": "-43.6776",
+          "c6": "4.10578",
+          "D0": "24.4543",
+          "D1": "-67.4509",
+          "D2": "-4.8489",
+          "D3": "-0.000544",
+          "C1": "-285.56594E-6",
+          "C2": "316.32993E-9",
+          "C3": "-1.0767272E-6"
+        },
+        "PREDEPLOYMENT_CALIB_COMMENT": "see TD269 Operating manual oxygen optode 4330, 4835, 4831; see Processing Argo OXYGEN data at the DAC level, Version 2.2 (DOI: http://dx.doi.org/10.13155/39795)",
+        "PREDEPLOYMENT_CALIB_DATE": "2020-01-01T00:00:00Z",
+        "parameter_vendorinfo": {
+          "example": "Vendors can add their own parameter info here; they can add any field they like as a fieldname below parameter_vendorinfo"
+        },
+        "predeployment_vendorinfo": {
+          "example": "Vendors can add their own predeployment info here; they can add any field they like as a fieldname below predeployment_vendorinfo"
+        }
+      },
+      {
+        "PARAMETER": "SDN:P01::OXYCPHAC",
+        "PARAMETER_SENSOR": "SDN:L05::351",
+        "PARAMETER_UNITS": "mbar",
+        "PARAMETER_ACCURACY": " ",
+        "PARAMETER_RESOLUTION": " ",
+        "PREDEPLOYMENT_CALIB_EQUATION": "TPHASE_DOXY=C1PHASE_DOXY-C2PHASE_DOXY; Phase_Pcorr=TPHASE_DOXY+Pcoef1*PRES/1000; CalPhase=PhaseCoef0+PhaseCoef1*Phase_Pcorr+PhaseCoef2*Phase_Pcorr^2+PhaseCoef3*Phase_Pcorr^3; Ksv=c0+c1*TEMP_DOXY+c2*TEMP_DOXY^2; MOLAR_DOXY=[((c3+c4*TEMP_DOXY)/(c5+c6*CalPhase))-1]/Ksv; Pcorr=1+((Pcoef2*TEMP+Pcoef3)*PRES)/1000; MOLAR_DOXY=MOLAR_DOXY*Pcorr; pH2Osat=1013.25*exp[D0+D1*(100/(TEMP+273.15))+D2*ln((TEMP+273.15)/100)]; Tcorr=44.6596*exp[2.00907+3.22014*Ts+4.05010*Ts^2+4.94457*Ts^3-2.56847e-1*Ts^4+3.88767*Ts^5]; Ts=ln[(298.15-TEMP)/(273.15+TEMP)]; PPOX_DOXY=MOLAR_DOXY*(0.20946*(1013.25-pH2Osat))/Tcorr*exp[0.317*PRES/(8.314*(TEMP+273.15))]",
+        "PREDEPLOYMENT_CALIB_COEFFICIENT_LIST": {
+          "Pcoef1": "0.1",
+          "Pcoef2": "0.00022",
+          "Pcoef3": "0.0419",
+          "PhaseCoef0": "-1.652",
+          "PhaseCoef1": "1",
+          "PhaseCoef2": "0",
+          "PhaseCoef3": "0",
+          "c0": "0.00261275",
+          "c1": "0.00011268",
+          "c2": "2.2309e-06",
+          "c3": "200.183",
+          "c4": "-0.223497",
+          "c5": "-43.6776",
+          "c6": "4.10578",
+          "D0": "24.4543",
+          "D1": "-67.4509",
+          "D2": "-4.8489",
+          "C0": "3.1201642E-3",
+          "C1": "-285.56594E-6",
+          "C2": "316.32993E-9",
+          "C3": "-1.0767272E-6"
+        },
+        "PREDEPLOYMENT_CALIB_COMMENT": "see TD269 Operating manual oxygen optode 4330, 4835, 4831; see Processing Argo OXYGEN data at the DAC level, Version 2.2 (DOI: http://dx.doi.org/10.13155/39795)",
+        "PREDEPLOYMENT_CALIB_DATE": "2020-01-01T00:00:00Z",
+        "parameter_vendorinfo": {
+          "example": "Vendors can add their own parameter info here; they can add any field they like as a fieldname below parameter_vendorinfo"
+        },
+        "predeployment_vendorinfo": {
+          "example": "Vendors can add their own predeployment info here; they can add any field they like as a fieldname below predeployment_vendorinfo"
+        }
+      }
+    ],
+    "instrument_vendorinfo": {
+      "example": "Vendors can add something about the whole instrument here; they can add field they like as a fieldname below instrument_vendorinfo"
+    }
+  }

--- a/tests/integration_tests/test_file_validation.py
+++ b/tests/integration_tests/test_file_validation.py
@@ -26,11 +26,11 @@ test_cases = [
         "platform_invalid_vocabs.json",
         [
             ValidationError(
-                message="Unknown NSV term: http://vocab.nerc.ac.uk/collection/R28/current/APF9/",
+                message="Unknown NVS term: http://vocab.nerc.ac.uk/collection/R28/current/APF9/",
                 path="PLATFORM.0.CONTROLLER_BOARD_TYPE_PRIMARY",
             ),
             ValidationError(
-                message="Unknown NSV term: http://vocab.nerc.ac.uk/collection/R28/current/USEA/",
+                message="Unknown NVS term: http://vocab.nerc.ac.uk/collection/R28/current/USEA/",
                 path="PLATFORM.0.CONTROLLER_BOARD_TYPE_SECONDARY",
             ),
         ],
@@ -39,7 +39,7 @@ test_cases = [
         "sensor_deprecated_vocab.json",
         [
             ValidationError(
-                message="Deprecated NSV term: http://vocab.nerc.ac.uk/collection/R03/current/NB_SAMPLE/",
+                message="Deprecated NVS term: http://vocab.nerc.ac.uk/collection/R03/current/NB_SAMPLE/",
                 path="PARAMETERS.0.PARAMETER",
             )
         ],

--- a/tests/integration_tests/test_user_defined_schema_validation.py
+++ b/tests/integration_tests/test_user_defined_schema_validation.py
@@ -1,0 +1,33 @@
+"""Test complete validation process for input files when validated against a user-supplied schema."""
+
+from pathlib import Path
+
+import pytest
+
+from argo_metadata_validator.models.results import ValidationError
+from argo_metadata_validator.validation import ArgoValidator
+
+test_cases = [
+    ["valid_sensor.json", []],
+    [
+        "invalid_sensor.json",
+        [
+            ValidationError(
+                message="'SENSORS' is a required property",
+                path="",
+            ),
+            ValidationError(message="Additional properties are not allowed ('SENSORZ' was unexpected)", path=""),
+        ],
+    ],
+]
+
+
+@pytest.mark.parametrize("file_path,expected_errors", test_cases)
+def test_validating_files_with_user_defined_schema(file_path, expected_errors):
+    """Test that validation works as expected with a user-defined schema."""
+    resolved_file_path = Path(__file__).parent.parent / "files" / "user_defined" / file_path
+    resolved_schema_path = Path(__file__).parent.parent / "files" / "user_defined" / "schema" / "sensor.schema.json"
+
+    errors = ArgoValidator().validate([str(resolved_file_path)], resolved_schema_path)
+
+    assert errors == {file_path: expected_errors}


### PR DESCRIPTION
This adds a new code path to allow a user-specified schema validation file to be specified.

- It modifies the validate method to add a new optional parameter called schema_path.
- If not provided (so it is set to None by default) the code will validate against the standard Argo validators.
- If supplied, it will use the schema file at schema_path in place of the Argo validation schemas.

So existing code should not be affected at all.
