### PR TITLE
Allow errors to be just warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ venv/
 .pytest_cache/
 
 test_json/
+
+.DS_store

--- a/argo_metadata_validator/cli.py
+++ b/argo_metadata_validator/cli.py
@@ -4,20 +4,25 @@ import json
 
 import click
 
-from argo_metadata_validator.models.results import ValidationError
+from argo_metadata_validator.models.results import ERROR, WARNING, ValidationError
 from argo_metadata_validator.validation import ArgoValidator
 
 
 def output_to_terminal(errors: dict[str, list[ValidationError]]):
     """Convert validation errors to terminal output."""
     for file, file_errors in errors.items():
+        error_count = len([x for x in file_errors if x.level == ERROR])
+        warning_count = len([x for x in file_errors if x.level == WARNING])
         if file_errors:
-            click.echo(click.style(f"{file} has {len(file_errors)} errors", fg="red"))
+            if error_count:
+                click.echo(click.style(f"{file} has {error_count} errors", fg="red"))
+            if warning_count:
+                click.echo(click.style(f"{file} has {warning_count} warnings", fg="yellow"))
         else:
             click.echo(click.style(f"{file} has no errors", fg="green"))
         click.echo("-----")
         for err in file_errors:
-            click.echo(click.style(f"{err.message} at path {err.path}", fg="red"))
+            click.echo(click.style(f"{err.message} at path {err.path}", fg="yellow" if err.level == WARNING else "red"))
 
 
 def output_to_json_string(errors: dict[str, list[ValidationError]]) -> str:

--- a/argo_metadata_validator/cli.py
+++ b/argo_metadata_validator/cli.py
@@ -29,7 +29,11 @@ def output_to_json_string(errors: dict[str, list[ValidationError]]) -> str:
     """Convert validation errors to a JSON-string output."""
     serialised = {}
     for file, file_errors in errors.items():
-        serialised[file] = {"is_valid": len(file_errors) == 0, "errors": [x.model_dump() for x in file_errors]}
+        serialised[file] = {
+            "is_valid": len(file_errors) == 0,
+            "errors": [x.model_dump(exclude="level") for x in filter(lambda y: y.level == ERROR, file_errors)],
+            "warnings": [x.model_dump(exclude="level") for x in filter(lambda y: y.level == WARNING, file_errors)],
+        }
     return json.dumps(serialised, indent=2)
 
 

--- a/argo_metadata_validator/models/results.py
+++ b/argo_metadata_validator/models/results.py
@@ -2,9 +2,13 @@
 
 from pydantic import BaseModel
 
+ERROR = 1
+WARNING = 0
+
 
 class ValidationError(BaseModel):
     """Model to hold validation errors."""
 
     message: str
     path: str | None = None
+    level: int

--- a/argo_metadata_validator/models/results.py
+++ b/argo_metadata_validator/models/results.py
@@ -11,4 +11,4 @@ class ValidationError(BaseModel):
 
     message: str
     path: str | None = None
-    level: int
+    level: int = ERROR

--- a/argo_metadata_validator/validation.py
+++ b/argo_metadata_validator/validation.py
@@ -9,7 +9,7 @@ from jsonschema.exceptions import ValidationError as JsonValidationError
 from argo_metadata_validator.constants import FLOAT_SCHEMA, PLATFORM_SCHEMA, SENSOR_SCHEMA
 from argo_metadata_validator.models.float import Float
 from argo_metadata_validator.models.platform import Platform
-from argo_metadata_validator.models.results import ValidationError
+from argo_metadata_validator.models.results import ERROR, WARNING, ValidationError
 from argo_metadata_validator.models.sensor import Sensor
 from argo_metadata_validator.schema_utils import (
     get_json_validator,
@@ -22,7 +22,10 @@ from argo_metadata_validator.vocab_utils import VocabTerms, expand_vocab, update
 
 
 def _parse_json_error(error: JsonValidationError) -> ValidationError:
-    return ValidationError(message=error.message, path=".".join([str(x) for x in error.path]))
+    error_path = ".".join([str(x) for x in error.path])
+    return ValidationError(
+        message=error.message, path=error_path, level=WARNING if "vendorinfo" in error_path else ERROR
+    )
 
 
 class ArgoValidator:
@@ -30,6 +33,7 @@ class ArgoValidator:
 
     all_json_data: dict[str, Any] = {}  # Keyed by the original filename
     validation_errors: dict[str, list[ValidationError]] = {}  # Keyed by the original filename
+    validation_warnings: dict[str, list[ValidationError]] = {}  # Keyed by the original filename
     argo_vocab_terms: VocabTerms
 
     def __init__(self):
@@ -86,7 +90,7 @@ class ArgoValidator:
             _type_: _description_
         """
         errors = self.validate([json_obj])
-        if any(len(errors[e]) > 0 for e in errors):
+        if any([x for x in errors[e] if x.level != WARNING] for e in errors):
             raise Exception("Data not valid, run the validation function for detailed errors.")
 
         key = f"JSdict.{id(json_obj)}" if isinstance(json_obj, dict) else Path(json_obj).name
@@ -108,7 +112,7 @@ class ArgoValidator:
             schema_path (Path, optional): A path to a schema file. Defaults to None.
 
         Returns:
-            list[str]: List of errors.
+            list[ValidationError]: List of errors.
         """
         if schema_path is None:
             schema_type = infer_schema_from_data(json_data)

--- a/tests/integration_tests/test_file_validation.py
+++ b/tests/integration_tests/test_file_validation.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from argo_metadata_validator.models.results import ValidationError
+from argo_metadata_validator.models.results import ERROR, ValidationError
 from argo_metadata_validator.validation import ArgoValidator
 
 test_cases = [
@@ -18,8 +18,13 @@ test_cases = [
             ValidationError(
                 message="'SENSORS' is a required property",
                 path="",
+                level=ERROR,
             ),
-            ValidationError(message="Additional properties are not allowed ('SENSORZ' was unexpected)", path=""),
+            ValidationError(
+                message="Additional properties are not allowed ('SENSORZ' was unexpected)",
+                path="",
+                level=ERROR,
+            ),
         ],
     ],
     [
@@ -28,10 +33,12 @@ test_cases = [
             ValidationError(
                 message="Unknown NVS term: http://vocab.nerc.ac.uk/collection/R28/current/APF9/",
                 path="PLATFORM.0.CONTROLLER_BOARD_TYPE_PRIMARY",
+                level=ERROR,
             ),
             ValidationError(
                 message="Unknown NVS term: http://vocab.nerc.ac.uk/collection/R28/current/USEA/",
                 path="PLATFORM.0.CONTROLLER_BOARD_TYPE_SECONDARY",
+                level=ERROR,
             ),
         ],
     ],
@@ -41,6 +48,7 @@ test_cases = [
             ValidationError(
                 message="Deprecated NVS term: http://vocab.nerc.ac.uk/collection/R03/current/NB_SAMPLE/",
                 path="PARAMETERS.0.PARAMETER",
+                level=ERROR,
             )
         ],
     ],

--- a/tests/integration_tests/test_user_defined_schema_validation.py
+++ b/tests/integration_tests/test_user_defined_schema_validation.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from argo_metadata_validator.models.results import ValidationError
+from argo_metadata_validator.models.results import ERROR, ValidationError
 from argo_metadata_validator.validation import ArgoValidator
 
 test_cases = [
@@ -15,8 +15,13 @@ test_cases = [
             ValidationError(
                 message="'SENSORS' is a required property",
                 path="",
+                level=ERROR,
             ),
-            ValidationError(message="Additional properties are not allowed ('SENSORZ' was unexpected)", path=""),
+            ValidationError(
+                message="Additional properties are not allowed ('SENSORZ' was unexpected)",
+                path="",
+                level=ERROR,
+            ),
         ],
     ],
 ]

--- a/tests/unit_tests/test_cli_utils.py
+++ b/tests/unit_tests/test_cli_utils.py
@@ -8,7 +8,7 @@ import click
 import pytest
 
 from argo_metadata_validator.cli import output_to_json_string, output_to_terminal
-from argo_metadata_validator.models.results import ValidationError
+from argo_metadata_validator.models.results import WARNING, ValidationError
 
 
 @pytest.fixture
@@ -18,6 +18,7 @@ def sample_errors():
         "file_1": [
             ValidationError(message="error 1", path="sensors"),
             ValidationError(message="error 2", path="parameters"),
+            ValidationError(message="warning 1", path="vendorinfo", level=WARNING),
         ],
         "file_2": [],
     }
@@ -29,13 +30,15 @@ def test_output_to_terminal(mocker, sample_errors):
 
     output_to_terminal(sample_errors)
 
-    assert mock_echo.call_count == 6
+    assert mock_echo.call_count == 8
     assert mock_echo.mock_calls[0] == call(click.style("file_1 has 2 errors", fg="red"))
-    assert mock_echo.mock_calls[1] == call("-----")
-    assert mock_echo.mock_calls[2] == call(click.style("error 1 at path sensors", fg="red"))
-    assert mock_echo.mock_calls[3] == call(click.style("error 2 at path parameters", fg="red"))
-    assert mock_echo.mock_calls[4] == call(click.style("file_2 has no errors", fg="green"))
-    assert mock_echo.mock_calls[5] == call("-----")
+    assert mock_echo.mock_calls[1] == call(click.style("file_1 has 1 warnings", fg="yellow"))
+    assert mock_echo.mock_calls[2] == call("-----")
+    assert mock_echo.mock_calls[3] == call(click.style("error 1 at path sensors", fg="red"))
+    assert mock_echo.mock_calls[4] == call(click.style("error 2 at path parameters", fg="red"))
+    assert mock_echo.mock_calls[5] == call(click.style("warning 1 at path vendorinfo", fg="yellow"))
+    assert mock_echo.mock_calls[6] == call(click.style("file_2 has no errors", fg="green"))
+    assert mock_echo.mock_calls[7] == call("-----")
 
 
 def test_output_json_string(sample_errors):
@@ -50,10 +53,12 @@ def test_output_json_string(sample_errors):
                     {"message": "error 1", "path": "sensors"},
                     {"message": "error 2", "path": "parameters"},
                 ],
+                "warnings": [{"message": "warning 1", "path": "vendorinfo"}],
             },
             "file_2": {
                 "is_valid": True,
                 "errors": [],
+                "warnings": [],
             },
         }
     )

--- a/tests/unit_tests/test_validation.py
+++ b/tests/unit_tests/test_validation.py
@@ -2,13 +2,14 @@
 
 import pytest
 
+from argo_metadata_validator.models.results import ValidationError
 from argo_metadata_validator.validation import ArgoValidator
 
 
 def test_model_parsing_invalid_data(mocker):
     """Test the validator's parse method mocking the case where the data is invalid."""
     validator = ArgoValidator()
-    mocker.patch.object(validator, "validate", return_value={"123.json": ["hi"]})
+    mocker.patch.object(validator, "validate", return_value={"123.json": [ValidationError(message="hi")]})
 
     with pytest.raises(Exception) as exc_info:
         validator.parse("123.json")


### PR DESCRIPTION
- vendorinfo errors will be marked as just warnings
- Warnings will display differently when using the CLI
- Warnings won't prevent the parse() method running on the data